### PR TITLE
Fixed typo in schema

### DIFF
--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -192,9 +192,9 @@
                                 "description": "Only used if operation = conversion",
                                 "type": "object",
                                 "additionalProperties": false,
-                                "required": ["comparions_operator", "aggregation_type", "breach_value"],
+                                "required": ["comparison_operator", "aggregation_type", "breach_value"],
                                 "properties": {
-                                    "comparions_operator": {
+                                    "comparison_operator": {
                                         "description": "One of gt or gte",
                                         "enum": ["gt", "gte"]
                                     },


### PR DESCRIPTION
There was a typo in the schema that caused schema validation errors for me. I confirmed that the schema in this repo is incorrect because if you resolve the schema validation error by changing the spelling to `comparions_operator`, the schema validation passes, but then there's an API error because it's expecting the field `comparison_operator`. 

I pip installed the library from this branch (`bugfix-schema-typo`) and that allowed me to create the metric in Eppo successfully.