### PR TITLE
Cleanup

### DIFF
--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -192,9 +192,9 @@
                                 "description": "Only used if operation = conversion",
                                 "type": "object",
                                 "additionalProperties": false,
-                                "required": ["comparions_operator", "aggregation_type", "breach_value"],
+                                "required": ["comparison_operator", "aggregation_type", "breach_value"],
                                 "properties": {
-                                    "comparions_operator": {
+                                    "comparison_operator": {
                                         "description": "One of gt or gte",
                                         "enum": ["gt", "gte"]
                                     },

--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -152,7 +152,7 @@
                             },
                             "operation": {
                                 "description": "Which aggregation to apply to the fact",
-                                "enum": ["sum", "count", "distinct_entity", "threshold", "conversion", "retention"]
+                                "enum": ["sum", "count", "distinct_entity", "threshold", "conversion", "retention", "count_distinct"]
                             },
                             "filters": {
                                 "description": "Optional fact property filters to apply",

--- a/tests/yaml/valid/purchases.yaml
+++ b/tests/yaml/valid/purchases.yaml
@@ -20,6 +20,7 @@ fact_sources:
     column: COUNTRY
   - name: Browser
     column: BROWSER
+  reference_url: https://github.com/Eppo-exp/eppo-metrics-sync
 metrics:
 - name: Unique Purchase by User
   entity: User # it would be nice if this was optional if there is exactly 1 entity defined above


### PR DESCRIPTION
Summary of changes:

- Fixed an error caused by referencing `valid.error_message`. This error made it so that if the schema was invalid, the error message wouldn't tell you _why_ because Python would throw an error trying to show the actual error.
- PEP8 fixes
- Added a reference URL to one of the test files to make sure that it passes the schema validation checks
- Moved a nested method to improve readability