### PR TITLE
Separated fact sources and metric definitions for a valid file to pro…

### DIFF
--- a/tests/yaml/valid/global_kpis/net_subcriptions_fact_source.yaml
+++ b/tests/yaml/valid/global_kpis/net_subcriptions_fact_source.yaml
@@ -16,13 +16,3 @@ fact_sources:
     facts:
       - name: Net Subscriptions
         column: event_value
-
-metrics:
-  - name: Net subscriptions
-    description: Sum of upgrade and downgrade events
-    entity: User
-    numerator:
-      fact_name: Net Subscriptions
-      operation: sum
-      winsorization_lower_percentile: 0.01
-      winsorization_upper_percentile: 0.99

--- a/tests/yaml/valid/global_kpis/net_subcriptions_metric.yaml
+++ b/tests/yaml/valid/global_kpis/net_subcriptions_metric.yaml
@@ -1,0 +1,9 @@
+metrics:
+  - name: Net subscriptions
+    description: Sum of upgrade and downgrade events
+    entity: User
+    numerator:
+      fact_name: Net Subscriptions
+      operation: sum
+      winsorization_lower_percentile: 0.01
+      winsorization_upper_percentile: 0.99


### PR DESCRIPTION
…vide coverage for this case

I took one of our "valid" metrics and split it into separate files to make it so our tests explicitly check that having separated files like this is valid.