### PR TITLE
Added a sync prefix

### DIFF
--- a/eppo_metrics_sync/__main__.py
+++ b/eppo_metrics_sync/__main__.py
@@ -3,27 +3,32 @@ import argparse
 from eppo_metrics_sync.eppo_metrics_sync import EppoMetricsSync
 
 if __name__ == '__main__':
-    
+
     parser = argparse.ArgumentParser(
         description="Scan specified directory for Eppo yaml files and sync with Eppo"
     )
     parser.add_argument("directory", help="The directory of yaml files to process")
     parser.add_argument("--dryrun", action="store_true", help="Run in dry run mode")
     parser.add_argument("--schema", help="One of: eppo[default], dbt-model", default='eppo')
+    parser.add_argument("--sync-prefix", help="Used for testing in a shared Q/A workspace. "
+                                              "Will use this as a sync tag and append all fact and metric definitions with this prefix.",
+                        required=False
+                        )
     parser.add_argument(
-        "--dbt-model-prefix", 
-        help="The warehouse and schema where the dbt models live", 
+        "--dbt-model-prefix",
+        help="The warehouse and schema where the dbt models live",
         default=None
     )
 
     args = parser.parse_args()
 
     eppo_metrics_sync = EppoMetricsSync(
-        directory = args.directory, 
+        directory=args.directory,
         schema_type=args.schema,
-        dbt_model_prefix=args.dbt_model_prefix
+        dbt_model_prefix=args.dbt_model_prefix,
+        sync_prefix=args.sync_prefix
     )
-    
+
     if args.dryrun:
         eppo_metrics_sync.read_yaml_files()
         eppo_metrics_sync.validate()


### PR DESCRIPTION
# Overview
This adds the ability to specify a `sync_prefix` CLI argument that provides a short-term solution to the problem of not having a local environment to test changes to certified facts/metrics.

# How it works
When a user wants to test changes in a staging workspace, they can provide a sync prefix like this:
`./eppo_metrics --sync-prefix="tyler_new_revenue_metric"`

the `--sync-prefix` would then be used as the sync tag in Eppo (it would have priority over the environment variable `EPPO_SYNC_TAG`), and then all facts sources and metrics would be prepended with the sync prefix to ensure that uniqueness constraints are met (assuming nobody else is using the same prefix). This gives users the ability to try out new metrics in a Q/A workspace without any risk of deleting or modifying someone else's metrics during testing. **This effectively gives everyone a personal sandbox for testing changes.** Once the teams have reviewed the changes, they can then put in a pull request into a `main` branch where teams must resolve conflicts before deploying changes to production (without a prefix). After changes have been sufficiently reviewed in Q/A, users with appropriate permissions can delete the corresponding `sync_tag` to keep the Q/A workspace clean.