### PR TITLE
updated schema to use new timeframe parameters

### DIFF
--- a/eppo_metrics_sync/eppo_metrics_sync.py
+++ b/eppo_metrics_sync/eppo_metrics_sync.py
@@ -82,7 +82,7 @@ class EppoMetricsSync:
                             self.load_eppo_yaml(yaml_path)
                         else:
                             self.validation_errors.append(
-                                f"Schema violation in {yaml_path}: \n{valid.error_message}"
+                                f"Schema violation in {yaml_path}: \n{valid['error_message']}"
                             )
                     
                     elif self.schema_type == 'dbt-model':

--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -216,13 +216,17 @@
                                     }
                                 }
                             },
-                            "aggregation_timeframe_value": {
-                                "description": "How many timeframe units since assignment to include (optional)",
-                                "value": "number"
+                            "aggregation_timeframe_start_value": {
+                                "description": "The start of the timeframe window defined in number of timeframe units following assignment (optional)",
+                                "type": "number"
+                            },
+                            "aggregation_timeframe_end_value": {
+                                "description": "The end of the timeframe window defined in number of timeframe units following assignment (optional)",
+                                "type": "number"
                             },
                             "aggregation_timeframe_unit": {
                                 "description": "What time unit to use: minutes, hours, days, or weeks (optional)",
-                                "enum": ["minutes", "hours", "days", "weeks"]
+                                "enum": ["minutes", "hours", "days", "weeks", "calendar_days"]
                             },
                             "winsorization_lower_percentile": {
                                 "description": "Percentile at which to clip aggregated metrics (optional)",
@@ -274,13 +278,17 @@
                                     }
                                 }
                             },
-                            "aggregation_timeframe_value": {
-                                "description": "How many timeframe units since assignment to include (optional)",
+                            "aggregation_timeframe_start_value": {
+                                "description": "The start of the timeframe window defined in number of timeframe units following assignment (optional)",
+                                "type": "number"
+                            },
+                            "aggregation_timeframe_end_value": {
+                                "description": "The end of the timeframe window defined in number of timeframe units following assignment (optional)",
                                 "type": "number"
                             },
                             "aggregation_timeframe_unit": {
                                 "description": "What time unit to use: minutes, hours, days, or weeks (optional)",
-                                "enum": ["minutes", "hours", "days", "weeks"]
+                                "enum": ["minutes", "hours", "days", "weeks", "calendar_days"]
                             },
                             "winsorization_lower_percentile": {
                                 "description": "Percentile at which to clip aggregated metrics (optional)",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,39 +5,36 @@ from eppo_metrics_sync.validation import unique_names, valid_fact_references, ag
 from eppo_metrics_sync.eppo_metrics_sync import EppoMetricsSync
 
 # If we use context.py we can do something like this instead
-#from .context import eppo_metric_sync
-#from .context import validation
+# from .context import eppo_metric_sync
+# from .context import validation
 
 
 test_yaml_dir = "tests/yaml/invalid"
 
 
 def test_unique_fact_source_names():
-
-    eppo_metrics_sync = EppoMetricsSync(directory = None)
+    eppo_metrics_sync = EppoMetricsSync(directory=None)
     eppo_metrics_sync.load_eppo_yaml(
-        path = test_yaml_dir + "/duplicated_fact_source_names.yaml")
-    
-    with pytest.raises(ValueError, match = "Fact source names are not unique: upgrades_table"):
+        path=test_yaml_dir + "/duplicated_fact_source_names.yaml")
+
+    with pytest.raises(ValueError, match="Fact source names are not unique: upgrades_table"):
         eppo_metrics_sync.validate()
 
 
 def test_unique_metric_names():
-
-    eppo_metrics_sync = EppoMetricsSync(directory = None)
+    eppo_metrics_sync = EppoMetricsSync(directory=None)
     eppo_metrics_sync.load_eppo_yaml(
-        path = test_yaml_dir + "/duplicated_metric_names.yaml")
-    
-    with pytest.raises(ValueError, match = "Metric names are not unique: Total Upgrades to Paid Plan"):
+        path=test_yaml_dir + "/duplicated_metric_names.yaml")
+
+    with pytest.raises(ValueError, match="Metric names are not unique: Total Upgrades to Paid Plan"):
         eppo_metrics_sync.validate()
 
 
 def test_unique_fact_names():
-
-    eppo_metrics_sync = EppoMetricsSync(directory = None)
+    eppo_metrics_sync = EppoMetricsSync(directory=None)
     eppo_metrics_sync.load_eppo_yaml(
-        path = test_yaml_dir + "/duplicated_fact_names.yaml")
-    
+        path=test_yaml_dir + "/duplicated_fact_names.yaml")
+
     with pytest.raises(ValueError, match="Fact names are not unique: upgrades"):
         eppo_metrics_sync.validate()
 
@@ -53,10 +50,10 @@ def test_unique_fact_names():
 
 
 def test_invalid_fact_reference():
-    eppo_metrics_sync = EppoMetricsSync(directory = None)
+    eppo_metrics_sync = EppoMetricsSync(directory=None)
     eppo_metrics_sync.load_eppo_yaml(
-        path = test_yaml_dir + "/invalid_fact_reference.yaml")
-    with pytest.raises(ValueError, match = re.escape("Invalid fact reference(s): revenue")):
+        path=test_yaml_dir + "/invalid_fact_reference.yaml")
+    with pytest.raises(ValueError, match=re.escape("Invalid fact reference(s): revenue")):
         eppo_metrics_sync.validate()
 
 
@@ -72,23 +69,22 @@ def test_invalid_winsorization_operation():
 def test_invalid_aggregation_for_timeframe():
     test_agg = {
         'operation': 'conversion',
-        'aggregation_timeframe_value': 1,
+        'aggregation_timeframe_end_value': 1,
         'aggregation_timeframe_unit': 'days',
         'conversion_threshold_days': 1
     }
-    
+
     res = aggregation_is_valid(test_agg)
-    assert res == 'Cannot specify aggregation_timeframe_value for operation conversion'
+    assert res == 'Cannot specify aggregation_timeframe_end_value for operation conversion'
 
 
 def test_invalid_timeframe_parameters():
     test_agg = {
         'operation': 'sum',
-        'aggregation_timeframe_value': 1
+        'aggregation_timeframe_end_value': 1
     }
 
-    expected_error = 'Either both or neither aggregation_timeframe_value and ' + \
-        'aggregation_timeframe_unit must be set'
+    expected_error = 'The aggregation_timeframe_unit must be set to use timeframe parameters.'
 
     res = aggregation_is_valid(test_agg)
     assert res == expected_error
@@ -102,7 +98,7 @@ def test_invalid_aggregation_parameter():
 
     res = aggregation_is_valid(test_agg)
     assert res == 'retention_threshold_days specified, but operation is sum'
-        
+
 
 def test_missing_conversion_threshold():
     test_agg = {
@@ -122,12 +118,14 @@ def test_extra_parameter_on_retention_metric():
     res = aggregation_is_valid(test_agg)
     assert res == 'Invalid parameter for retention aggregation: conversion_threshold_days'
 
+
 def test_count_distinct():
     test_agg = {
         'operation': 'count_distinct',
-        'aggregation_timeframe_value': 1,
+        'aggregation_timeframe_start_value': 1,
+        'aggregation_timeframe_end_value': 7,
         'aggregation_timeframe_unit': 'days'
     }
-    
+
     res = aggregation_is_valid(test_agg)
     assert res == None


### PR DESCRIPTION
We recently updated the way that aggregation timeframes are specified. Before, we only specified the end of the window (`aggregation_timeframe_value`) and the window was assumed to start at the exposure timestamp. Now we have the ability to specify a window with an offset, so we have `aggregation_timeframe_start_value` and `aggregation_timeframe_end_value`). I updated the package and the unit tests to accommodate this update.