### PR TITLE
Add guardrail_cutoff to eppo_metric_schema.json

### DIFF
--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -137,7 +137,7 @@
                         "type": "number"
                     },
                     "reference_url": {
-                        "description": "URL to use for 'Open in GitHub' in Eppo UI (optional)",                
+                        "description": "URL to use for 'Open in GitHub' in Eppo UI (optional)",
                         "type": "string"
                     },
                     "guardrail_cutoff": {

--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -140,6 +140,10 @@
                         "description": "URL to use for 'Open in GitHub' in Eppo UI (optional)",
                         "type": "string"
                     },
+                    "guardrail_cutoff": {
+                        "description": "URL to use for 'Open in GitHub' in Eppo UI (optional)",
+                        "type": "number"
+                    },
                     "numerator": {
                         "description": "Specify how the numerator of this metric should be aggregated",
                         "type": "object",

--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -137,11 +137,11 @@
                         "type": "number"
                     },
                     "reference_url": {
-                        "description": "URL to use for 'Open in GitHub' in Eppo UI (optional)",
+                        "description": "URL to use for 'Open in GitHub' in Eppo UI (optional)",                
                         "type": "string"
                     },
                     "guardrail_cutoff": {
-                        "description": "URL to use for 'Open in GitHub' in Eppo UI (optional)",
+                        "description": "If a metric is expected to increase, this value should be negative, to warn when the metric is decreasing by more than this value.",
                         "type": "number"
                     },
                     "numerator": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='eppo_metrics_sync',
-    version='0.0.6',
+    version='0.0.7',
     packages=find_packages(),
     install_requires=[
         'PyYAML', 'jsonschema', 'requests'


### PR DESCRIPTION
This Pr is a direct consequence of the release of [Non-inferiority testing with Guardrail Cutoffs](https://updates.eppo.cloud/en/non_inferiority-testing-with-guardrail-cutoffs) and of the possibility to use this feature from our metric sync API.

### How it has been tested
Successfully synced a yml file from with guardrail_cutoff option in it to a test workspace. 
I even caught the error `  "Guardrail cutoff value should be negative for increasing metrics"` when trying to set the metric with incorrect settings.