### PR TITLE
Allow fact sources to always fully refresh

### DIFF
--- a/eppo_metrics_sync/eppo_metrics_sync.py
+++ b/eppo_metrics_sync/eppo_metrics_sync.py
@@ -13,8 +13,8 @@ from eppo_metrics_sync.validation import (
 from eppo_metrics_sync.dbt_model_parser import DbtModelParser
 from eppo_metrics_sync.helper import load_yaml
 
-API_ENDPOINT = 'https://eppo.cloud/api/v1/metrics/sync'
-
+host = os.getenv('EPPO_API_HOST', 'https://eppo.cloud')
+API_ENDPOINT = f'{host}/api/v1/metrics/sync'
 
 class EppoMetricsSync:
     def __init__(

--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -100,6 +100,10 @@
                                 }
                             }
                         }
+                    },
+                    "always_full_refresh": {
+                        "description": "If true, this fact source will always be fully refreshed (optional)",
+                        "type": "boolean"
                     }
                 }
             }

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='eppo_metrics_sync',
-    version='0.0.8',
+    version='0.1.0',
     packages=find_packages(),
     install_requires=[
         'PyYAML', 'jsonschema', 'requests'

--- a/tests/yaml/valid/global_kpis/upgrades.yaml
+++ b/tests/yaml/valid/global_kpis/upgrades.yaml
@@ -18,6 +18,7 @@ fact_sources:
         column: event_value
       - name: upgrade_value
         column: upgrade_value
+    always_full_refresh: true
 
 metrics:
   - name: Total Upgrades to Paid Plan


### PR DESCRIPTION
### Summary
* Allow fact sources to optionally define `always_full_refresh`
* Allow for overriding of hostname/server to use by setting `EPPO_API_HOST` environment variable