### PR TITLE
Emiel/add type property to metrics

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Eppo
+Copyright (c) 2023-2024 Eppo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -71,7 +71,7 @@
                                     "description": "User-friendly description of the fact",
                                     "type": "string"
                                 },
-                                "desired_change" : {
+                                "desired_change": {
                                     "description": "Specify whether or not increases in the fact are desired",
                                     "enum": ["increase", "decrease"]
                                 }
@@ -124,6 +124,10 @@
                         "description": "A user-friendly description of the fact",
                         "type": "string"
                     },
+                    "type": {
+                        "description": "The kind of metric to be calculated",
+                        "enum": ["simple", "ratio", "funnel", "percentile"]
+                    },
                     "entity": {
                         "description": "Must exactly match entity's name in Eppo UI",
                         "type": "string"
@@ -146,7 +150,7 @@
                     },
                     "guardrail_cutoff": {
                         "description": "If a metric is expected to increase, this value should be negative, to warn when the metric is decreasing by more than this value.",
-                        "type": "number"
+                        "type": ["number", "null"]
                     },
                     "numerator": {
                         "description": "Specify how the numerator of this metric should be aggregated",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='eppo_metrics_sync',
-    version='0.1.0',
+    version='0.1.1',
     packages=find_packages(),
     install_requires=[
         'PyYAML', 'jsonschema', 'requests'

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -54,7 +54,7 @@ def test_valid_guardrail_cutoff_signs():
     eppo_metrics_sync = EppoMetricsSync(directory = None)
     eppo_metrics_sync.load_yaml(
         path = test_yaml_dir + "/duplicated_fact_property_names.yaml")
-    
+
     with pytest.raises(ValueError, match = "Fact property names are not unique: device"):
         eppo_metrics_sync.validate()"""
 

--- a/tests/yaml/invalid/invalid_metric_type.yaml
+++ b/tests/yaml/invalid/invalid_metric_type.yaml
@@ -1,0 +1,16 @@
+fact_sources:
+  - name: upgrades_table
+    sql: select * from upgrades
+    timestamp_column: ts
+    entities:
+      - entity_name: user
+        column: user_id
+    facts:
+      - name: upgrades
+metrics:
+  - name: Total Upgrades to Paid Plan
+    entity: User
+    type: Nonexistent
+    numerator:
+      fact_name: upgrades
+      operation: sum

--- a/tests/yaml/valid/purchases.yaml
+++ b/tests/yaml/valid/purchases.yaml
@@ -1,7 +1,7 @@
 fact_sources:
 - name: Purchase
   sql: |
-    SELECT 
+    SELECT
       events.*
     FROM customer_db.onboarding.events as events
     WHERE event_type = 'Revenue'
@@ -30,6 +30,7 @@ metrics:
     operation: distinct_entity
 - name: AOV
   entity: User
+  type: ratio
   numerator:
     fact_name: Purchase
     operation: sum


### PR DESCRIPTION
A customer has noticed that adding the `type` property to a `.yaml` file causes the metric sync to error out with the following message:
```
Schema violation in **.yaml: 
Additional properties are not allowed ('type' was unexpected)
```

Meanwhile, the yml they were trying to sync was gathered using the `COPY YAML` button on Eppo's UI, and the API is able to handle a `type` field. So here we introduce a `type` field to the schema, and make it an `ENUM` accepting only the values allowed currently when creating a new metric in the Eppo UI.