### PR TITLE
Make fact column nullable

### DIFF
--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -65,7 +65,7 @@
                                 },
                                 "column": {
                                     "description": "The column that contains this fact (if not specified, will use each record)",
-                                    "type": "string"
+                                    "type":  ["string", "null"]
                                 },
                                 "description": {
                                     "description": "User-friendly description of the fact",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='eppo_metrics_sync',
-    version='0.1.1',
+    version='0.1.2',
     packages=find_packages(),
     install_requires=[
         'PyYAML', 'jsonschema', 'requests'


### PR DESCRIPTION
Fixing this bug mentioned by Anthony.
<img width="614" alt="Screenshot 2024-12-12 at 10 32 27 AM" src="https://github.com/user-attachments/assets/4b6921e9-b494-403d-a721-7af906c191ad" />

### How has it been tested
I've installed the Python package locally and successfully synced a yaml file with a "column": null filter.
