### PR TITLE
Emiel/bump sigstore signing version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eppo_metrics_sync"
-version = "0.1.3"
+version = "0.1.4"
 description = "Sync metrics to Eppo"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
Due to a package misconfiguration between versions,  we need to bump the `SigStore` GitHub action to v3.0.0 to resolve this