### PR TITLE
Fix imports in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "eppo_metrics_sync"
-version = "0.1.3"
+version = "0.1.4"
 description = "Sync metrics to Eppo"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -15,4 +15,7 @@ dependencies = [
 ]
 
 [tool.setuptools]
-include-package-data = true
+packages = ["eppo_metrics_sync"]
+
+[tool.setuptools.package-data]
+eppo_metrics_sync = ["schema/*"]


### PR DESCRIPTION
Fixes [EXP-4274](https://linear.app/eppo/issue/EXP-4274/eppo-metrics-sync-fails-with-release-013)
Our new Python packaging that moved from `setup.py` to `pyproject.toml` was introduced with [PR 26](https://github.com/Eppo-exp/eppo-metrics-sync/pull/26). We used the `include-package-data` which only imports non-.py file from the current directory. `eppo_metric_schema.json` is in the `schema` directory and was not imported when users ran pip install. That lead to Strava pinning to version 0.1.2 because our latest release throws back an error message. Potentially all customers using this package will be impacted when running pip install `eppo_metrics_sync`.

Current change should fix it as per Perplexity
![Screenshot 2024-12-16 at 5 56 43 PM](https://github.com/user-attachments/assets/f7e16343-7213-40bb-9dd1-2a34a3a05942)

## Testing
- Verified package builds locally using `python -m build`, locally installed the package from `eppo_metrics_sync-0.1.4.tar.gz` and ran a sync to QA.