### PR TITLE
EXP-5021 Add ability to allow_upgrades in metric sync python script

### DIFF
--- a/eppo_metrics_sync/__main__.py
+++ b/eppo_metrics_sync/__main__.py
@@ -8,6 +8,7 @@ if __name__ == '__main__':
         description="Scan specified directory for Eppo yaml files and sync with Eppo"
     )
     parser.add_argument("directory", help="The directory of yaml files to process")
+    parser.add_argument("--allow-upgrades", action="store_true", help="Allow existing non-certified metrics/fact sources to become certified")
     parser.add_argument("--dryrun", action="store_true", help="Run in dry run mode")
     parser.add_argument("--schema", help="One of: eppo[default], dbt-model", default='eppo')
     parser.add_argument("--sync-prefix", help="Used for testing in a shared Q/A workspace. "
@@ -26,7 +27,8 @@ if __name__ == '__main__':
         directory=args.directory,
         schema_type=args.schema,
         dbt_model_prefix=args.dbt_model_prefix,
-        sync_prefix=args.sync_prefix
+        sync_prefix=args.sync_prefix,
+        allow_upgrades=args.allow_upgrades
     )
 
     if args.dryrun:

--- a/eppo_metrics_sync/eppo_metrics_sync.py
+++ b/eppo_metrics_sync/eppo_metrics_sync.py
@@ -23,7 +23,8 @@ class EppoMetricsSync:
             directory,
             schema_type='eppo',
             dbt_model_prefix=None,
-            sync_prefix=None
+            sync_prefix=None,
+            allow_upgrades=False
     ):
         self.directory = directory
         self.fact_sources = []
@@ -32,6 +33,7 @@ class EppoMetricsSync:
         self.schema_type = schema_type
         self.dbt_model_prefix = dbt_model_prefix
         self.sync_prefix = sync_prefix
+        self.allow_upgrades = allow_upgrades
 
         # temporary: ideally would pull this from Eppo API
         package_root = os.path.dirname(os.path.abspath(__file__))
@@ -150,7 +152,7 @@ class EppoMetricsSync:
             "metrics": self.metrics
         }
 
-        response = requests.post(API_ENDPOINT, json=payload, headers=headers)
+        response = requests.post(f'{API_ENDPOINT}{"?allow_upgrades=true" if self.allow_upgrades else ""}', json=payload, headers=headers)
 
         if response.status_code < 400:
             print('Metrics synced')


### PR DESCRIPTION
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: EXP-5021

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)
Customer issue: MyFitnessPal was attempting to use python script to certify an existing fact source, but it didn't work because we don't offer the option to "upgrade" existing fact sources / metrics to certified in the script

## Description
[//]: # (Describe your changes in detail)
Adds the argument in the script, which passes it along to the public API call

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)
Tested in QA with the same scenario @MaloChevillotte was using to reproduce the issue.

Before: 
```
$ .venv/bin/python3 -m eppo_metrics_sync ~/Documents/metric-sync
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/htrajan/code/eppo-metrics-sync/eppo_metrics_sync/__main__.py", line 36, in <module>
    eppo_metrics_sync.sync()
  File "/Users/htrajan/code/eppo-metrics-sync/eppo_metrics_sync/eppo_metrics_sync.py", line 158, in sync
    raise Exception(f"Request failed {response.status_code}: {response.text}")
Exception: Request failed 400: ["Can't create a fact source with name 'Ride App Opens'. Fact source with the same name was created in another metric sync"]
```

After:
```
$ .venv/bin/python3 -m eppo_metrics_sync --allow-upgrades ~/Documents/metric-sync
Metrics synced
```
Fact Source is now showing as Certified in QA:
<img width="1375" alt="Screenshot 2025-03-11 at 4 22 06 PM" src="https://github.com/user-attachments/assets/7c271b97-9c6e-43ae-8a93-2bf71aa791a0" />

## What is expected of reviewers?
[//]: # (Tell your reviewers if there is something specific you'd like them to do before they approve your pull request.)
👀 