### PR TITLE
Multiple top-dirs and auto schema.

### DIFF
--- a/eppo_metrics_sync/__main__.py
+++ b/eppo_metrics_sync/__main__.py
@@ -7,10 +7,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Scan specified directory for Eppo yaml files and sync with Eppo"
     )
-    parser.add_argument("directory", help="The directory of yaml files to process")
+    parser.add_argument("directories", help="The directories of yaml files to process", nargs="*")
     parser.add_argument("--allow-upgrades", action="store_true", help="Allow existing non-certified metrics/fact sources to become certified")
     parser.add_argument("--dryrun", action="store_true", help="Run in dry run mode")
-    parser.add_argument("--schema", help="One of: eppo[default], dbt-model", default='eppo')
+    parser.add_argument("--schema", help="One of: eppo[default], dbt-model", default='eppo', choices=["eppo", "dbt-model", "auto"])
     parser.add_argument("--sync-prefix", help="Used for testing in a shared Q/A workspace. "
                                               "Will use this as a sync tag and append all fact and metric definitions with this prefix.",
                         required=False
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     eppo_metrics_sync = EppoMetricsSync(
-        directory=args.directory,
+        directory=args.directories,
         schema_type=args.schema,
         dbt_model_prefix=args.dbt_model_prefix,
         sync_prefix=args.sync_prefix,

--- a/eppo_metrics_sync/eppo_metrics_sync.py
+++ b/eppo_metrics_sync/eppo_metrics_sync.py
@@ -26,7 +26,11 @@ class EppoMetricsSync:
             sync_prefix=None,
             allow_upgrades=False
     ):
-        self.directory = directory
+        if directory is None:
+            directory = []
+        elif isinstance(directory, str):
+            directory = [directory]
+        self.directories = directory
         self.fact_sources = []
         self.metrics = []
         self.validation_errors = []
@@ -73,13 +77,15 @@ class EppoMetricsSync:
 
     def read_yaml_files(self):
         # Recursively scan the directory for YAML files and load valid ones
-        for root, _, files in os.walk(self.directory):
+        for root, _, files in self._scan_directories():
             for file in files:
                 if file.endswith(".yaml") or file.endswith(".yml"):
 
                     yaml_path = os.path.join(root, file)
 
-                    if self.schema_type == 'eppo':
+                    schema_type = self._detect_schema(yaml_path) if self.schema_type == 'auto' else self.schema_type
+
+                    if schema_type == 'eppo':
                         valid = self.yaml_is_valid(yaml_path)
                         if valid['passed']:
                             self.load_eppo_yaml(yaml_path)
@@ -88,7 +94,7 @@ class EppoMetricsSync:
                                 f"Schema violation in {yaml_path}: \n{valid['error_message']}"
                             )
 
-                    elif self.schema_type == 'dbt-model':
+                    elif schema_type == 'dbt-model':
                         self.load_dbt_yaml(yaml_path)
 
                     else:
@@ -98,6 +104,16 @@ class EppoMetricsSync:
             raise ValueError(
                 'No valid yaml files found. ' + ', '.join(self.validation_errors)
             )
+
+    def _scan_directories(self):
+        for d in self.directories:
+            yield from os.walk(d)
+
+    def _detect_schema(self, yaml_path):
+        yaml_data = load_yaml(yaml_path)
+        if 'version' in yaml_data and 'models' in yaml_data:
+            return 'dbt-model'
+        return 'eppo'
 
     def _add_sync_prefix(self):
         for source in self.fact_sources:

--- a/eppo_metrics_sync/helper.py
+++ b/eppo_metrics_sync/helper.py
@@ -1,5 +1,7 @@
+from functools import cache
 import yaml
 
+@cache
 def load_yaml(path):
     try:
         with open(path, 'r') as file:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,10 @@ def test_cli_dryrun_option(run_cli):
     result = run_cli(['tests/yaml/valid', '--dryrun'])
     assert result.returncode == 0
 
+def test_cli_two_directories_auto(run_cli):
+    result = run_cli(['tests/yaml/valid', 'tests/yaml/dbt/valid/', '--dryrun', '--schema', 'auto', '--dbt-model-prefix', 'foo'])
+    assert result.returncode == 0
+
 def test_cli_invalid_directory(run_cli):
     result = run_cli(['tests/yaml/invalid'])
     assert result.returncode != 0


### PR DESCRIPTION
Hi. I would like to invoke the tool like this:
python3 -m eppo_metrics_sync --dbt-model-prefix foo --schema auto --dryrun $(find . -name tripadvisor -type d -prune)

In order to gather all the facts and metrics available for each workspace in a single go, regardless how they are laid out on the filesystem. Would it be possible to take a look at this? Thanks.
