### PR TITLE
feat: add optional sync metadata (creator_email, updater_email, team_name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ export EPPO_API_KEY="your-api-key"
 export EPPO_SYNC_TAG="your-sync-tag" # optional
 
 export EPPO_REFERENCE_URL="your-reference-url" # optional
+
+# Optional: set metric creator, updater, and team (sync-level; env overrides YAML)
+export EPPO_CREATOR_EMAIL="data-team@company.com"
+export EPPO_UPDATER_EMAIL="ci-bot@company.com"
+export EPPO_TEAM_NAME="Analytics"
 ```
 
 2. Create your metrics YAML files (see [Documentation](#documentation))
@@ -54,6 +59,9 @@ Options:
 -   `--sync-prefix` Prefix for fact/metric names (useful for testing)
 -   `--dbt-model-prefix` Warehouse/schema prefix for dbt models
 -   `--allow-upgrades` Allow existing non-certified metrics/fact sources to become certified
+-   `--creator-email` Sync-level creator email (overrides YAML; can also set `EPPO_CREATOR_EMAIL`)
+-   `--updater-email` Sync-level updater email (overrides YAML; can also set `EPPO_UPDATER_EMAIL`)
+-   `--team-name` Sync-level team name (overrides YAML; can also set `EPPO_TEAM_NAME`)
 
 #### When to use `--allow-upgrades`
 
@@ -123,6 +131,29 @@ When using guardrail metrics (`is_guardrail: true` with `guardrail_cutoff`):
 - If `desired_change: "decrease"` → `guardrail_cutoff` must be **positive**
 
 **Note:** The validation uses the metric's `desired_change` if specified, otherwise it falls back to the fact's `desired_change`. This allows you to override the fact-level direction when creating guardrail metrics.
+
+### Optional sync metadata (creator, updater, team)
+
+You can set **creator_email**, **updater_email**, and **team_name** at the sync level (applying to all metrics) and optionally override per metric in YAML. Resolution order: env vars / CLI args override YAML. If you omit these in a later sync, the API clears the corresponding fields (omit = clear).
+
+- **Sync-level (defaults for all metrics):** Set in YAML at the root next to `sync_tag` / `reference_url` / `fact_sources` / `metrics`, or via env (`EPPO_CREATOR_EMAIL`, `EPPO_UPDATER_EMAIL`, `EPPO_TEAM_NAME`) or CLI (`--creator-email`, `--updater-email`, `--team-name`).
+- **Per-metric override:** Add `creator_email`, `updater_email`, or `team_name` on individual entries in the `metrics` array.
+
+Example (sync-level in YAML):
+
+```yaml
+creator_email: data-team@company.com
+updater_email: ci-bot@company.com
+team_name: Analytics
+fact_sources: [ ... ]
+metrics:
+  - name: My Metric
+    entity: User
+    ...
+  - name: Other Metric
+    team_name: Data Science   # override for this metric only
+    ...
+```
 
 ## Documentation
 

--- a/eppo_metrics_sync/__main__.py
+++ b/eppo_metrics_sync/__main__.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import argparse
 from eppo_metrics_sync.eppo_metrics_sync import EppoMetricsSync
@@ -20,15 +21,37 @@ if __name__ == '__main__':
         help="The warehouse and schema where the dbt models live",
         default=None
     )
+    parser.add_argument(
+        "--creator-email",
+        help="Email for metric creator/author (sync-level). Overrides YAML. Can also set EPPO_CREATOR_EMAIL.",
+        default=None
+    )
+    parser.add_argument(
+        "--updater-email",
+        help="Email for last updater (sync-level). Overrides YAML. Can also set EPPO_UPDATER_EMAIL.",
+        default=None
+    )
+    parser.add_argument(
+        "--team-name",
+        help="Team name to associate with metrics (sync-level). Overrides YAML. Can also set EPPO_TEAM_NAME.",
+        default=None
+    )
 
     args = parser.parse_args()
+
+    creator_email = args.creator_email or os.environ.get('EPPO_CREATOR_EMAIL')
+    updater_email = args.updater_email or os.environ.get('EPPO_UPDATER_EMAIL')
+    team_name = args.team_name or os.environ.get('EPPO_TEAM_NAME')
 
     eppo_metrics_sync = EppoMetricsSync(
         directory=args.directory,
         schema_type=args.schema,
         dbt_model_prefix=args.dbt_model_prefix,
         sync_prefix=args.sync_prefix,
-        allow_upgrades=args.allow_upgrades
+        allow_upgrades=args.allow_upgrades,
+        creator_email=creator_email,
+        updater_email=updater_email,
+        team_name=team_name
     )
 
     if args.dryrun:

--- a/eppo_metrics_sync/eppo_metrics_sync.py
+++ b/eppo_metrics_sync/eppo_metrics_sync.py
@@ -24,7 +24,10 @@ class EppoMetricsSync:
             schema_type='eppo',
             dbt_model_prefix=None,
             sync_prefix=None,
-            allow_upgrades=False
+            allow_upgrades=False,
+            creator_email=None,
+            updater_email=None,
+            team_name=None
     ):
         self.directory = directory
         self.fact_sources = []
@@ -34,6 +37,10 @@ class EppoMetricsSync:
         self.dbt_model_prefix = dbt_model_prefix
         self.sync_prefix = sync_prefix
         self.allow_upgrades = allow_upgrades
+        self.creator_email = creator_email
+        self.updater_email = updater_email
+        self.team_name = team_name
+        self._sync_metadata_yaml = {}  # sync-level creator_email, updater_email, team_name from YAML (last file wins)
 
         # temporary: ideally would pull this from Eppo API
         package_root = os.path.dirname(os.path.abspath(__file__))
@@ -47,6 +54,13 @@ class EppoMetricsSync:
             self.fact_sources.extend(yaml_data['fact_sources'])
         if 'metrics' in yaml_data:
             self.metrics.extend(yaml_data['metrics'])
+        # Sync-level optional metadata from YAML (last file wins when scanning directory)
+        if 'creator_email' in yaml_data:
+            self._sync_metadata_yaml['creator_email'] = yaml_data['creator_email']
+        if 'updater_email' in yaml_data:
+            self._sync_metadata_yaml['updater_email'] = yaml_data['updater_email']
+        if 'team_name' in yaml_data:
+            self._sync_metadata_yaml['team_name'] = yaml_data['team_name']
 
     def load_dbt_yaml(self, path):
         if not self.dbt_model_prefix:
@@ -139,8 +153,25 @@ class EppoMetricsSync:
         reference_url = os.getenv('EPPO_REFERENCE_URL')
         if not reference_url:
             return payload
-        
+
         payload["reference_url"] = reference_url
+        return payload
+
+    def _attach_sync_metadata(self, payload):
+        """
+        Optionally attach sync-level creator_email, updater_email, team_name.
+        Env vars (EPPO_CREATOR_EMAIL, EPPO_UPDATER_EMAIL, EPPO_TEAM_NAME) override YAML/config.
+        Omitted fields are not added so the API can clear them (omit = clear).
+        """
+        creator_email = os.getenv('EPPO_CREATOR_EMAIL') or self.creator_email or self._sync_metadata_yaml.get('creator_email')
+        updater_email = os.getenv('EPPO_UPDATER_EMAIL') or self.updater_email or self._sync_metadata_yaml.get('updater_email')
+        team_name = os.getenv('EPPO_TEAM_NAME') or self.team_name or self._sync_metadata_yaml.get('team_name')
+        if creator_email:
+            payload['creator_email'] = creator_email
+        if updater_email:
+            payload['updater_email'] = updater_email
+        if team_name:
+            payload['team_name'] = team_name
         return payload
 
     def sync(self):
@@ -164,6 +195,7 @@ class EppoMetricsSync:
             "metrics": self.metrics
         }
         payload = self._attach_reference_url(payload)
+        payload = self._attach_sync_metadata(payload)
 
         response = requests.post(f'{API_ENDPOINT}{"?allow_upgrades=true" if self.allow_upgrades else ""}', json=payload, headers=headers)
 

--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -13,6 +13,22 @@
             "description": "An optional URL to link to in the Eppo UI",
             "type": "string"
         },
+        "creator_email": {
+            "description": "Email of the user to set as metric creator/author. Resolved to a company user; if not found or omitted, creator_id is cleared.",
+            "type": "string",
+            "format": "email"
+        },
+        "updater_email": {
+            "description": "Email of the user to set as last updater. Same resolution/clearing rules as creator_email.",
+            "type": "string",
+            "format": "email"
+        },
+        "team_name": {
+            "description": "Name of the team to associate with the metric (1–200 chars). Resolved by name within the company.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200
+        },
         "fact_sources": {
             "description": "A fact source, corresponds to a fact SQL definition in the Eppo UI",
             "type": "array",
@@ -189,6 +205,22 @@
                     "reference_url": {
                         "description": "An optional URL to link to in the Eppo UI",
                         "type": "string"
+                    },
+                    "creator_email": {
+                        "description": "Override sync-level creator. Email of the user to set as metric creator/author.",
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "updater_email": {
+                        "description": "Override sync-level updater. Email of the user to set as last updater.",
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "team_name": {
+                        "description": "Override sync-level team. Name of the team to associate with the metric (1–200 chars).",
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 200
                     },
                     "guardrail_cutoff": {
                         "description": "If a metric is expected to increase, this value should be negative, to warn when the metric is decreasing by more than this value.",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -222,3 +222,50 @@ metrics:
             # Restore original environment
             os.environ.clear()
             os.environ.update(original_env)
+
+
+def test_sync_metadata_integration():
+    """
+    Test that creator_email, updater_email, team_name from YAML and env are attached to the payload.
+    Env overrides YAML. Per-metric overrides are preserved in metric objects.
+    """
+    from eppo_metrics_sync.eppo_metrics_sync import EppoMetricsSync
+
+    test_yaml_dir = str(Path(__file__).parent / "yaml" / "valid" / "sync_metadata.yaml")
+    eppo_sync = EppoMetricsSync(directory=None)
+    eppo_sync.load_eppo_yaml(test_yaml_dir)
+    eppo_sync.validate()
+
+    payload = {
+        "sync_tag": "test_tag",
+        "fact_sources": eppo_sync.fact_sources,
+        "metrics": eppo_sync.metrics
+    }
+    payload = eppo_sync._attach_reference_url(payload)
+    payload = eppo_sync._attach_sync_metadata(payload)
+
+    # Sync-level from YAML
+    assert payload.get("creator_email") == "data-team@company.com"
+    assert payload.get("updater_email") == "ci-bot@company.com"
+    assert payload.get("team_name") == "Analytics"
+
+    # Per-metric override preserved on second metric
+    metrics = payload["metrics"]
+    assert len(metrics) == 2
+    assert "team_name" not in metrics[0]
+    assert metrics[1].get("team_name") == "Data Science"
+
+    # Env overrides YAML
+    original_env = os.environ.copy()
+    try:
+        os.environ["EPPO_CREATOR_EMAIL"] = "env-override@company.com"
+        payload2 = {
+            "sync_tag": "test_tag",
+            "fact_sources": eppo_sync.fact_sources,
+            "metrics": eppo_sync.metrics
+        }
+        payload2 = eppo_sync._attach_sync_metadata(payload2)
+        assert payload2["creator_email"] == "env-override@company.com"
+    finally:
+        os.environ.clear()
+        os.environ.update(original_env)

--- a/tests/yaml/valid/sync_metadata.yaml
+++ b/tests/yaml/valid/sync_metadata.yaml
@@ -1,0 +1,32 @@
+# Sync-level optional metadata (creator_email, updater_email, team_name)
+# Per-metric overrides can be set on individual metrics.
+reference_url: https://github.com/Eppo-exp/eppo-metrics-sync
+creator_email: data-team@company.com
+updater_email: ci-bot@company.com
+team_name: Analytics
+fact_sources:
+    - name: Test Source
+      sql: |
+          SELECT ts AS TS, user_id, value
+          FROM test_table
+      timestamp_column: TS
+      entities:
+          - entity_name: User
+            column: user_id
+      facts:
+          - name: Test Fact
+            column: value
+metrics:
+    - name: Metric With Defaults
+      entity: User
+      type: simple
+      numerator:
+          fact_name: Test Fact
+          operation: sum
+    - name: Metric With Override
+      entity: User
+      type: simple
+      team_name: Data Science
+      numerator:
+          fact_name: Test Fact
+          operation: sum


### PR DESCRIPTION
## Summary

This PR adds support for the new **optional sync-level and per-metric metadata fields** on the Metric Sync API: `creator_email`, `updater_email`, and `team_name`. These allow setting metric creator/author, last updater, and associated team when syncing.

**Dependency:** This work depends on [Eppo-exp/eppo#13697](https://github.com/Eppo-exp/eppo/pull/13697), which introduces these optional fields on the Metric Sync API.

**Resolves:** [FFESUPPORT-407](https://datadoghq.atlassian.net/browse/FFESUPPORT-407)

---

## Behavior

- **Sync-level defaults:** `creator_email`, `updater_email`, and `team_name` can be set once per sync and apply to all metrics in the payload.
- **Per-metric overrides:** Any metric in the `metrics` array can override with its own `creator_email`, `updater_email`, or `team_name`.
- **Omit = clear:** If a field is omitted in a later sync (neither at sync nor per-metric level), the API clears the corresponding DB field. This client only sends these fields when they are configured, so omitting them from config/YAML/env results in them not being sent and the API clearing as documented.

---

## Changes

### 1. Schema (`eppo_metric_schema.json`)

- **Sync-level:** Added optional `creator_email` (string, format email), `updater_email` (string, format email), and `team_name` (string, 1–200 chars) at the root, next to `sync_tag`, `reference_url`, `fact_sources`, `metrics`.
- **Per-metric:** Added the same three optional properties on each metric object so per-metric overrides are valid in the schema.

### 2. Core logic (`eppo_metrics_sync.py`)

- **Constructor:** `EppoMetricsSync` now accepts optional `creator_email`, `updater_email`, `team_name` (e.g. from CLI).
- **YAML loading:** `load_eppo_yaml()` reads root-level `creator_email`, `updater_email`, `team_name` and stores them in `_sync_metadata_yaml` (last file wins when scanning a directory).
- **Payload:** New `_attach_sync_metadata(payload)` adds sync-level `creator_email`, `updater_email`, `team_name` to the request body when set. Precedence: **env → constructor (CLI) → YAML**. Fields that are not set are not sent (API “omit = clear” behavior).
- **Per-metric:** Metrics are sent as-is; any `creator_email`, `updater_email`, or `team_name` on a metric dict (from YAML) are included in that metric object.

### 3. CLI (`__main__.py`)

- New optional flags: `--creator-email`, `--updater-email`, `--team-name`.
- Values can also come from `EPPO_CREATOR_EMAIL`, `EPPO_UPDATER_EMAIL`, `EPPO_TEAM_NAME`; CLI args take precedence over env.

### 4. Tests and sample YAML

- **`tests/yaml/valid/sync_metadata.yaml`:** Example with sync-level `creator_email`, `updater_email`, `team_name` and one metric that overrides `team_name`.
- **`tests/test_integration.py`:** `test_sync_metadata_integration()` asserts sync-level from YAML, per-metric override on the correct metric, and that env overrides YAML for sync-level creator.

### 5. README

- Documented the three env vars and three CLI options.
- Added a short “Optional sync metadata (creator, updater, team)” section with YAML placement and an example.

---

## Configuration sources (precedence)

1. **Env vars:** `EPPO_CREATOR_EMAIL`, `EPPO_UPDATER_EMAIL`, `EPPO_TEAM_NAME`
2. **CLI:** `--creator-email`, `--updater-email`, `--team-name`
3. **YAML:** Root-level `creator_email`, `updater_email`, `team_name` (last file wins when scanning a directory)

Higher precedence overrides lower. Per-metric overrides in YAML are always passed through on the corresponding metric objects.

---

## Checklist

- [x] Schema updated for sync-level and per-metric optional fields
- [x] Sync-level metadata read from YAML and attached to payload with env/CLI override
- [x] CLI and env vars documented and tested
- [x] Per-metric overrides preserved in payload
- [x] README updated
- [x] New test and sample YAML added; all existing tests pass
