### PR TITLE
feat: add --no-certify flag to control metric certification

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Options:
 -   `--sync-prefix` Prefix for fact/metric names (useful for testing)
 -   `--dbt-model-prefix` Warehouse/schema prefix for dbt models
 -   `--allow-upgrades` Allow existing non-certified metrics/fact sources to become certified
+-   `--no-certify` Sync without certifying — synced fact sources and metrics remain editable in the Eppo UI
+
+#### When to use `--no-certify`
+
+By default, synced metrics and fact sources are **certified**: they are locked from editing in the Eppo UI. Use `--no-certify` when you want to manage definitions in code but still allow team members to edit them in the UI (e.g., during an evaluation period or for metrics that are collaboratively maintained).
 
 #### When to use `--allow-upgrades`
 

--- a/eppo_metrics_sync/__main__.py
+++ b/eppo_metrics_sync/__main__.py
@@ -9,6 +9,7 @@ if __name__ == '__main__':
     )
     parser.add_argument("directory", help="The directory of yaml files to process")
     parser.add_argument("--allow-upgrades", action="store_true", help="Allow existing non-certified metrics/fact sources to become certified")
+    parser.add_argument("--no-certify", action="store_true", help="Sync without certifying: synced fact sources and metrics remain editable in the Eppo UI")
     parser.add_argument("--dryrun", action="store_true", help="Run in dry run mode")
     parser.add_argument("--schema", help="One of: eppo[default], dbt-model", default='eppo')
     parser.add_argument("--sync-prefix", help="Used for testing in a shared Q/A workspace. "
@@ -28,7 +29,8 @@ if __name__ == '__main__':
         schema_type=args.schema,
         dbt_model_prefix=args.dbt_model_prefix,
         sync_prefix=args.sync_prefix,
-        allow_upgrades=args.allow_upgrades
+        allow_upgrades=args.allow_upgrades,
+        is_certified=not args.no_certify
     )
 
     if args.dryrun:

--- a/eppo_metrics_sync/eppo_metrics_sync.py
+++ b/eppo_metrics_sync/eppo_metrics_sync.py
@@ -24,7 +24,8 @@ class EppoMetricsSync:
             schema_type='eppo',
             dbt_model_prefix=None,
             sync_prefix=None,
-            allow_upgrades=False
+            allow_upgrades=False,
+            is_certified=True
     ):
         self.directory = directory
         self.fact_sources = []
@@ -34,6 +35,7 @@ class EppoMetricsSync:
         self.dbt_model_prefix = dbt_model_prefix
         self.sync_prefix = sync_prefix
         self.allow_upgrades = allow_upgrades
+        self.is_certified = is_certified
 
         # temporary: ideally would pull this from Eppo API
         package_root = os.path.dirname(os.path.abspath(__file__))
@@ -165,7 +167,13 @@ class EppoMetricsSync:
         }
         payload = self._attach_reference_url(payload)
 
-        response = requests.post(f'{API_ENDPOINT}{"?allow_upgrades=true" if self.allow_upgrades else ""}', json=payload, headers=headers)
+        params = {}
+        if self.allow_upgrades:
+            params['allow_upgrades'] = 'true'
+        if not self.is_certified:
+            params['is_certified'] = 'false'
+
+        response = requests.post(API_ENDPOINT, params=params, json=payload, headers=headers)
 
         if response.status_code < 400:
             print('Metrics synced')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import subprocess
 import pytest
+from unittest.mock import patch, MagicMock
 
 pytest_plugins = ["pytester"]
 
@@ -20,3 +21,43 @@ def test_cli_dryrun_option(run_cli):
 def test_cli_invalid_directory(run_cli):
     result = run_cli(['tests/yaml/invalid'])
     assert result.returncode != 0
+
+
+class TestIsCertifiedParam:
+    """Tests for the is_certified query parameter (--no-certify flag)."""
+
+    def _make_sync(self, is_certified=True, allow_upgrades=False):
+        from eppo_metrics_sync.eppo_metrics_sync import EppoMetricsSync
+        return EppoMetricsSync(
+            directory='tests/yaml/valid',
+            is_certified=is_certified,
+            allow_upgrades=allow_upgrades,
+        )
+
+    @patch.dict('os.environ', {'EPPO_API_KEY': 'test-key', 'EPPO_SYNC_TAG': 'test-tag'})
+    @patch('eppo_metrics_sync.eppo_metrics_sync.requests.post')
+    def test_default_does_not_send_is_certified(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        syncer = self._make_sync(is_certified=True)
+        syncer.sync()
+        _, kwargs = mock_post.call_args
+        assert 'is_certified' not in kwargs.get('params', {})
+
+    @patch.dict('os.environ', {'EPPO_API_KEY': 'test-key', 'EPPO_SYNC_TAG': 'test-tag'})
+    @patch('eppo_metrics_sync.eppo_metrics_sync.requests.post')
+    def test_no_certify_sends_is_certified_false(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        syncer = self._make_sync(is_certified=False)
+        syncer.sync()
+        _, kwargs = mock_post.call_args
+        assert kwargs['params']['is_certified'] == 'false'
+
+    @patch.dict('os.environ', {'EPPO_API_KEY': 'test-key', 'EPPO_SYNC_TAG': 'test-tag'})
+    @patch('eppo_metrics_sync.eppo_metrics_sync.requests.post')
+    def test_no_certify_with_allow_upgrades(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=200)
+        syncer = self._make_sync(is_certified=False, allow_upgrades=True)
+        syncer.sync()
+        _, kwargs = mock_post.call_args
+        assert kwargs['params']['is_certified'] == 'false'
+        assert kwargs['params']['allow_upgrades'] == 'true'


### PR DESCRIPTION
## Summary

- Adds a `--no-certify` CLI flag that passes `is_certified=false` to the Eppo API's `POST /api/v1/metrics/sync` endpoint.
- By default (without the flag), synced fact sources and metrics are certified (locked from UI editing), preserving existing behavior.
- Refactors query parameter construction from manual f-string URL building to `requests.post(params=...)` for cleaner handling of multiple query params.

## Context

A client requested the ability to sync metrics without certifying them, so they remain editable in the Eppo UI. The `is_certified` query parameter already exists on the API server side but was not exposed in this CLI package. See [FFESUPPORT-621](https://datadoghq.atlassian.net/browse/FFESUPPORT-621).

Companion PR on the Eppo API: [Eppo-exp/eppo#13968](https://github.com/Eppo-exp/eppo/pull/13968) (documents the `is_certified` and `allow_upgrades` query params in the Swagger docs).

## Changes

- **`__main__.py`**: New `--no-certify` argument, passed as `is_certified=not args.no_certify`
- **`eppo_metrics_sync.py`**: New `is_certified` constructor param (default `True`), query params built via dict instead of f-string
- **`README.md`**: Documents `--no-certify` flag with usage guidance
- **`tests/test_cli.py`**: 3 new tests covering default behavior, `--no-certify`, and the combination with `--allow-upgrades`

## Test plan

- [x] All 37 existing + new tests pass locally
- [x] CI passes