### PR TITLE
[FFESUPPORT-738] Add optional team_id field to metrics and fact sources schema

### DIFF
--- a/eppo_metrics_sync/schema/eppo_metric_schema.json
+++ b/eppo_metrics_sync/schema/eppo_metric_schema.json
@@ -129,6 +129,10 @@
                             }
                         }
                     },
+                    "team_id": {
+                        "description": "Optional team ID to associate this fact source with a team in Eppo",
+                        "type": "integer"
+                    },
                     "always_full_refresh": {
                         "description": "If true, this fact source will always be fully refreshed (optional)",
                         "type": "boolean"
@@ -505,6 +509,10 @@
                             "increase",
                             "decrease"
                         ]
+                    },
+                    "team_id": {
+                        "description": "Optional team ID to associate this metric with a team in Eppo",
+                        "type": "integer"
                     }
                 }
             }


### PR DESCRIPTION
Adds team_id as an optional string property on both metrics and fact_sources items in the JSON schema, allowing YAML definitions to associate metrics and fact sources with a team in Eppo.
Tested with a locally compiled python lib:
`pip install -e /Users/malo.chevillotte/repos/eppo-metrics-sync` and then synced a metric with a team in QA.
<img width="541" height="339" alt="Screenshot 2026-05-29 at 10 41 48 AM" src="https://github.com/user-attachments/assets/f14fa2da-3b20-4662-956f-57f78627e292" />
<img width="1401" height="256" alt="Screenshot 2026-05-29 at 10 41 56 AM" src="https://github.com/user-attachments/assets/147e6d4f-a442-42a4-b4d9-d75720f62660" />
