### PR TITLE
Use setuptools-scm to derive version from git tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .venv
 .pytest_cache
 __pycache__
+eppo_metrics_sync/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "eppo_metrics_sync"
-version = "0.1.16"
+dynamic = ["version"]
 description = "Sync metrics to Eppo"
 readme = "README.md"
 requires-python = ">=3.7"
@@ -13,6 +13,9 @@ dependencies = [
     "jsonschema",
     "requests",
 ]
+
+[tool.setuptools_scm]
+version_file = "eppo_metrics_sync/_version.py"
 
 [tool.setuptools]
 packages = ["eppo_metrics_sync"]


### PR DESCRIPTION
## Summary
- Removes hardcoded `version` from `pyproject.toml`
- Adds `setuptools-scm` — version is derived from the git release tag at build time
- Adds `eppo_metrics_sync/_version.py` to `.gitignore` (generated file)
- No changes to `publish.yml` needed

## Test plan
- [x] Run `pip install setuptools-scm build && python3 -m build` locally and confirm wheel name reflects current tag
- [x] Cut a release with a new tag and confirm PyPI package version matches